### PR TITLE
Use the password as encryption key

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { MouseEventHandler, useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import Record, { RecordData } from "@/classes/record"
 import downloadRecords from "@/functions/downloadRecords"
 import { DataGrid } from "@mui/x-data-grid"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -364,7 +364,7 @@ const HomePage = () => {
     return (
       <main className="flex h-screen w-screen justify-center items-center p-4 box-border bg-slate-700">
         <div className="flex-1 max-w-[400px] flex flex-col gap-4 p-8 bg-white shadow rounded">
-          <h1 className="m-0 text-xl">Strava Club</h1>
+          <h1 className="m-0 text-xl">AutoRek Strava Club</h1>
           <p className="m-0 mb-2">
             A valid password is required to access this app
           </p>
@@ -392,7 +392,7 @@ const HomePage = () => {
   return (
     <main className="flex flex-col items-center p-5 gap-2 min-h-screen box-border bg-slate-700">
       <h1 className="text-2xl font-bold text-center m-0 mb-2 leading-none text-white">
-        Strava Club
+        AutoRek Strava Club
       </h1>
       <div className="flex-1 w-full max-w-[1200px] flex flex-col box-border bg-white shadow rounded">
         <nav className="px-4 box-border text-slate-300 bg-slate-200 w-full rounded-t shadow border-0 border-b border-solid border-slate-300">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { MouseEventHandler, useCallback, useEffect, useState } from "react"
 import Record, { RecordData } from "@/classes/record"
 import downloadRecords from "@/functions/downloadRecords"
 import { DataGrid } from "@mui/x-data-grid"
@@ -40,12 +40,8 @@ import useLocalStorage from "@/functions/useLocalStorage"
 type ActivityType = "" | "Run" | "Walk" | "Ride"
 
 const HomePage = () => {
-  const [password, setPassword] = useLocalStorage<string>(
-    "password",
-    ""
-  )
-  const [candidatePassword, setCandidatePassword] =
-    useState<string>("")
+  const [password, setPassword] = useLocalStorage<string>("password", "")
+  const [candidatePassword, setCandidatePassword] = useState<string>("")
   const [connectionError, setConnectionError] = useState<string>("")
   const [loading, setLoading] = useState<boolean>(true)
   const [records, setRecords] = useState<Record[]>([])
@@ -72,8 +68,8 @@ const HomePage = () => {
     let downloadedRecords = null
     try {
       downloadedRecords = await downloadRecords(password)
-    } catch {
-      setConnectionError("Invalid password")
+    } catch (e: any) {
+      setConnectionError(e.message)
     }
 
     if (downloadedRecords === null) {
@@ -307,6 +303,14 @@ const HomePage = () => {
       : handleDialogUnselectAthlete(name)
   }
 
+  const handlePasswordSubmission = () => {
+    if (candidatePassword === password) {
+      getRecords()
+      return
+    }
+    setPassword(candidatePassword)
+  }
+
   const clearData = () => {
     setPassword("")
     setCandidatePassword("")
@@ -321,7 +325,6 @@ const HomePage = () => {
       label={name}
       onDelete={() => handleUnselectAthlete(name)}
       sx={{
-        
         color: "white",
         backgroundColor: "#64748b",
         "& .MuiChip-deleteIcon": {
@@ -360,7 +363,7 @@ const HomePage = () => {
   if (records.length === 0)
     return (
       <main className="flex h-screen w-screen justify-center items-center p-4 box-border bg-slate-700">
-        <div className="flex-1 max-w-[500px] flex flex-col gap-4 p-8 bg-white shadow rounded">
+        <div className="flex-1 max-w-[400px] flex flex-col gap-4 p-8 bg-white shadow rounded">
           <h1 className="m-0 text-xl">Strava Club</h1>
           <p className="m-0 mb-2">
             A valid password is required to access this app
@@ -378,10 +381,7 @@ const HomePage = () => {
             helperText={connectionError}
           />
           <div className="flex justify-end">
-            <Button
-              size="small"
-              onClick={() => setPassword(candidatePassword)}
-            >
+            <Button size="small" onClick={handlePasswordSubmission}>
               Connect
             </Button>
           </div>

--- a/functions/downloadRecords.ts
+++ b/functions/downloadRecords.ts
@@ -15,7 +15,7 @@ export default async function downloadRecords(password: string) {
   // Decrypt the encrypted SAS token using the password
   let decryptedSasToken = ""
   try {
-    // Password is the decryption key
+    // Password is the encryption key
     decryptedSasToken = CryptoJS.AES.decrypt(
       ENCRYPTED_SAS_TOKEN,
       password

--- a/functions/downloadRecords.ts
+++ b/functions/downloadRecords.ts
@@ -32,15 +32,15 @@ export default async function downloadRecords(password: string) {
   // Download the records using the decrypted SAS token
   const sasUrlWithToken = `${SAS_URL}?${decryptedSasToken}`
   try {
-    const response = await fetch(sasUrlWithToken);
+    const response = await fetch(sasUrlWithToken)
     if (response.ok) {
-      const jsonText = await response.text();
-      const jsonArray = JSON.parse(jsonText);
-      return jsonArray;
+      const jsonText = await response.text()
+      const jsonArray = JSON.parse(jsonText)
+      return jsonArray
     } else {
-      throw new Error("Failed to download records");
+      throw new Error("Failed to download records")
     }
   } catch (error) {
-    throw new Error("Failed to connect to the server");
+    throw new Error("Failed to connect to the server")
   }
 }

--- a/functions/downloadRecords.ts
+++ b/functions/downloadRecords.ts
@@ -1,14 +1,46 @@
-const CryptoJS = require("crypto-js");
+const CryptoJS = require("crypto-js")
+
+const SAS_URL =
+  "https://stravafunctionappautorek.blob.core.windows.net/records2/records.json"
+const ENCRYPTED_SAS_TOKEN =
+  "U2FsdGVkX1/6Z4alzcNhwWWYU7yi510sxv6k2VkSD94MYPfYokfTtFaJqqpii6dEc50fiJMaRRdNgbI09fgAknu34nLE80gNAo8AlTEtbgnW65EHiqTbGvsDxyb2vpA3AtEFJJO3fuX0dDispR4hIXL8sKC4qsnV2WNK7wBsaBclOhU9VYjV336BoeThi82tv08tP5fHe5NWLjSUpT3yYw=="
+const DECRYPTED_SAS_TOKEN_LENGTH = 134
 
 export default async function downloadRecords(password: string) {
-  const sasUrl = CryptoJS.AES.decrypt(password, "key").toString(CryptoJS.enc.Utf8)
-  const response = await fetch(sasUrl)
+  // Validate the password
+  if (password.length < 8 || password.length > 32) {
+    throw new Error("Invalid password")
+  }
 
-  if (response.ok) {
-    const jsonText = await response.text()
-    const jsonArray = JSON.parse(jsonText)
-    return jsonArray
-  } else {
-    throw new Error("Failed to download records")
+  // Decrypt the encrypted SAS token using the password
+  let decryptedSasToken = ""
+  try {
+    // Password is the decryption key
+    decryptedSasToken = CryptoJS.AES.decrypt(
+      ENCRYPTED_SAS_TOKEN,
+      password
+    ).toString(CryptoJS.enc.Utf8)
+  } catch (error) {
+    throw new Error("Invalid password")
+  }
+
+  // Validate the decrypted token
+  if (decryptedSasToken.length !== DECRYPTED_SAS_TOKEN_LENGTH) {
+    throw new Error("Invalid password")
+  }
+
+  // Download the records using the decrypted SAS token
+  const sasUrlWithToken = `${SAS_URL}?${decryptedSasToken}`
+  try {
+    const response = await fetch(sasUrlWithToken);
+    if (response.ok) {
+      const jsonText = await response.text();
+      const jsonArray = JSON.parse(jsonText);
+      return jsonArray;
+    } else {
+      throw new Error("Failed to download records");
+    }
+  } catch (error) {
+    throw new Error("Failed to connect to the server");
   }
 }

--- a/functions/downloadRecords.ts
+++ b/functions/downloadRecords.ts
@@ -1,9 +1,7 @@
 const CryptoJS = require("crypto-js")
 
-const SAS_URL =
-  "https://stravafunctionappautorek.blob.core.windows.net/records2/records.json"
-const ENCRYPTED_SAS_TOKEN =
-  "U2FsdGVkX1/6Z4alzcNhwWWYU7yi510sxv6k2VkSD94MYPfYokfTtFaJqqpii6dEc50fiJMaRRdNgbI09fgAknu34nLE80gNAo8AlTEtbgnW65EHiqTbGvsDxyb2vpA3AtEFJJO3fuX0dDispR4hIXL8sKC4qsnV2WNK7wBsaBclOhU9VYjV336BoeThi82tv08tP5fHe5NWLjSUpT3yYw=="
+const SAS_URL = process.env.NEXT_PUBLIC_SAS_URL
+const ENCRYPTED_SAS_TOKEN = process.env.NEXT_PUBLIC_ENCRYPTED_SAS_TOKEN
 const DECRYPTED_SAS_TOKEN_LENGTH = 134
 
 export default async function downloadRecords(password: string) {


### PR DESCRIPTION
Use the password as the encryption key because it can be much shorter than the encrypted token. The URL is no longer encrypted because it is not sensitive, only the token is encrypted.